### PR TITLE
feat: add Python 3 and Ulauncher v5 support

### DIFF
--- a/ChromeBookmarks.py
+++ b/ChromeBookmarks.py
@@ -88,9 +88,9 @@ class ChromeBookmarks(Extension):
                 bookmark_url = bookmark['url'].encode('utf-8')
                 item = ExtensionResultItem(
                     icon=browser_imgs.get(browser),
-                    name='%s' % bookmark_name,
-                    description='%s' % bookmark_url,
-                    on_enter=OpenUrlAction(bookmark_url)
+                    name='%s' % bookmark_name.decode('utf-8'),
+                    description='%s' % bookmark_url.decode('utf-8'),
+                    on_enter=OpenUrlAction(bookmark_url.decode('utf-8'))
                 )
                 items.append(item)
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,5 @@
 {
-  "manifest_version": "1",
-  "api_version": "1",
+  "required_api_version": "^2.0.0",
   "name": "Google Chrome Bookmarks",
   "description": "Search and launch Google Chrome bookmarks",
   "developer_name": "Dmitry Antonenko",

--- a/versions.json
+++ b/versions.json
@@ -1,0 +1,10 @@
+[
+    {
+        "required_api_version": "^1.0.0",
+        "commit": "python2"
+    },
+    {
+        "required_api_version": "^2.0.0",
+        "commit": "master"
+    }
+]


### PR DESCRIPTION
This PR adds to support to the new Ulauncher API as well as Python 3.

**Note** Before merging this PR, make sure you create a "python2" branch from the current master to keep this extension working in an older version. If you want to give another name to the branch, just edit the "versions.json" file accordingly.

You can also check the Ulauncher migration documentation for more details: http://docs.ulauncher.io/en/latest/extensions/migration.html